### PR TITLE
Change RN version to 0.66.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ node {
     version.set("16.14.0")
 }
 
-val reactNativeVersion = "0.66.4"
+val reactNativeVersion = "0.66.2"
 val defaultCompileSdkVersion = 30
 val defaultMinSdkVersion = 21
 val defaultTargetSdkVersion = 30


### PR DESCRIPTION
The version we currently support in GB-mobile is 0.66.2 ([reference](https://github.com/WordPress/gutenberg/blob/6693c055af5031a9fd823e468762d85ace2e8dba/package.json#L202)), so we should match it.