### PR TITLE
Add Buildkite with publishing to S3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,17 @@
+common-params:
+  &docker-container
+  docker#v3.8.0:
+    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
+    propagate-environment: true
+    environment:
+      # DO NOT MANUALLY SET THESE VALUES!
+      # They are passed from the Buildkite agent to the Docker container
+      - "AWS_ACCESS_KEY"
+      - "AWS_SECRET_KEY"
+
+steps:
+  - label: "Publish to S3"
+    plugins:
+      - *docker-container
+    command: |
+      ./gradlew publish

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 common-params:
   &docker-container
   docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
+    image: "public.ecr.aws/automattic/android-build-image:bc7c60a898d89d968aa8202c6b5bd08f91c1779e"
     propagate-environment: true
     environment:
       # DO NOT MANUALLY SET THESE VALUES!
@@ -14,4 +14,7 @@ steps:
     plugins:
       - *docker-container
     command: |
+      source /root/.bashrc
+      nvm install && nvm use
+      npm install
       ./gradlew publish

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,4 +17,5 @@ steps:
       source /root/.bashrc
       nvm install && nvm use
       npm install
-      ./gradlew publish
+
+      .buildkite/publish-libraries.sh

--- a/.buildkite/publish-libraries.sh
+++ b/.buildkite/publish-libraries.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Publish each project individually after verifying the specific version is not already published
+
+PROJECTS=(
+react-native-get-random-values
+react-native-reanimate
+react-native-safe-area-context
+react-native-screen
+react-native-svg
+react-native-webview
+react-native-masked-view
+react-native-clipboard
+react-native-gesture-handler
+)
+
+for project in "${PROJECTS[@]}"
+do
+    EXIT_CODE=0
+    ./gradlew :$project:assertVersionIsNotAlreadyPublished || EXIT_CODE=$?
+    # If the project is not published already, publish it
+    if [ $EXIT_CODE -eq 0 ]; then
+        ./gradlew :$project:publishS3PublicationToS3Repository
+    fi
+done

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,6 @@ subprojects {
 
     tasks.withType(com.automattic.android.publish.PrepareToPublishToS3Task::class.java) {
         val packageVersion = getPackageVersion(project.name)
-        println("Publishing configuration:\n\tartifactId=\"${project.name}\"\n\tversion=\"$packageVersion\"")
 
         // Override the default behaviour of 'publish-to-s3' plugin since we always want to specify the version
         tagName = packageVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,7 @@
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.caching=true
+
 android.useAndroidX=true
 android.enableJetifier=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,16 @@
 pluginManagement {
     plugins {
         id("com.android.library").version("4.2.2")
+        id("com.automattic.android.publish-to-s3").version("0.7.0")
     }
     repositories {
+        maven {
+            url = uri("https://a8c-libs.s3.amazonaws.com/android")
+            content {
+                includeGroup("com.automattic.android")
+                includeGroup("com.automattic.android.publish-to-s3")
+            }
+        }
         gradlePluginPortal()
         google()
     }


### PR DESCRIPTION
This PR adds Buildkite with publishing to S3 using our [publish-to-s3-gradle-plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin). 

Due to the different nature of this project, the publishing setup is a little more complicated than other projects. Speficially, we need to set the `tagName` manually for the `PrepareToPublishToS3Task`. We normally pass this information from the command line using the Buildkite build parameters, but since we need to publish a specific version from the `package.json`, we are overriding this information.

Another complication in this setup is checking if a version is already published. In other projects, we want to fail the build because besides exceptional circumstances (mostly due to mistakes by developers) the CI wouldn't try to publish the same version. In this project, because we are publishing specified versions and we handle several projects, instead of failing the publish, we'll check if a version is already published and if it's, we won't try to publish it again.

Checking if the version is published will still result in a Gradle error. This is intentional with the idea that we'll see what's happening in the logs. The error for the `assertVersionIsNotAlreadyPublished` is instead handled in the bash script. This setup allows us to fail the Buildkite job if there is a genuine error in publishing.

---

One final note is that I had to create [a separate Docker image](https://github.com/wordpress-mobile/docker-android-build-image/pull/7) that has both Android and `nvm` setup. I didn't want to do this because it's not something we typically need, but I had a lot of trouble getting `nvm` setup from the Buildkite steps. I don't think this is particularly important for us and this setup is good enough for the moment. We'll certainly need to address this at some point, but let's try to figure out the more important stuff first.

---

The rest of the setup should be familiar, but I'd be happy to explain anything else that might not be clear.

**To test:**
* Notice the Buildkite job successfully publishing each package in 39c569378d43851bb02363eca80d3e50b4fe0357. I've removed all the existing versions before running this job, so they were all successfully published.
* Notice that even though Buildkite job for ea3e02525cf5840a4f09eb98ed95556bf77b15d5 (an empty commit) was successul, the logs show that it didn't actually try to publish anything since all the versions were already published.