### PR TITLE
Add build tools version to project properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,11 +13,13 @@ node {
 val defaultCompileSdkVersion = 30
 val defaultMinSdkVersion = 21
 val defaultTargetSdkVersion = 30
+val defaultBuildToolsVersion = "30.0.2"
 
 // Set project extra properties
 project.ext.set("compileSdkVersion", defaultCompileSdkVersion)
 project.ext.set("minSdkVersion", defaultMinSdkVersion)
 project.ext.set("targetSdkVersion", defaultTargetSdkVersion)
+project.ext.set("buildToolsVersion", defaultBuildToolsVersion)
 
 // Fetch dependencies versions from package.json
 val packageJson = JSONObject(File("$rootDir/package.json").readText())


### PR DESCRIPTION
I noticed when building the libraries the following warning:
```
WARNING:: The specified Android SDK Build Tools version (26.0.3) is ignored, as it is below the minimum supported version (30.0.2) for Android Gradle Plugin 4.2.2.
Android SDK Build Tools 30.0.2 will be used.
To suppress this warning, remove "buildToolsVersion '26.0.3'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
```

For this reason, I decided to add the build tools version to the project properties, so the libraries can get the right version.