### PR TITLE
Upgrade default compile and target sdk version to Android API 31

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
     id("com.automattic.android.publish-to-s3") apply false
 }
 
-val defaultCompileSdkVersion = 30
+val defaultCompileSdkVersion = 31
 val defaultMinSdkVersion = 21
-val defaultTargetSdkVersion = 30
+val defaultTargetSdkVersion = 31
 val excludeAppGlideModule = true
 
 // Set project extra properties


### PR DESCRIPTION
This PR is related to the upgrade effort to Android 12 in Gutenberg Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/issues/5181.

This PR basically only updates the default values for `compileSdkVersion` and `targetSdkVersion` to use version 31.