### PR TITLE
Upgrade default compile and target sdk version to Android API 33 (Android 13)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ import org.json.JSONObject
 // Although this allows different clients to use different artifacts, since we only have one client
 // this is now the most important use case for this implementation. Instead, this implementation
 // aims to make it easier to test publisher changes without having to override the artifacts.
-val publisherVersion = "v1"
+val publisherVersion = "v2"
 
 plugins {
     id("com.android.library") apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,9 @@ plugins {
     id("com.automattic.android.publish-to-s3") apply false
 }
 
-val defaultCompileSdkVersion = 30
+val defaultCompileSdkVersion = 33
 val defaultMinSdkVersion = 21
-val defaultTargetSdkVersion = 30
+val defaultTargetSdkVersion = 33
 val excludeAppGlideModule = true
 
 // Set project extra properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 val defaultCompileSdkVersion = 33
-val defaultMinSdkVersion = 21
+val defaultMinSdkVersion = 24
 val defaultTargetSdkVersion = 33
 val excludeAppGlideModule = true
 


### PR DESCRIPTION
**Related to https://github.com/WordPress/gutenberg/pull/50731.**

This PR bumps the default sdk version to API 33. In order to re-generate the binaries, the publisher version has been bumped too.