### PR TITLE
Bump `react-native-webview` to version `11.26.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4930,9 +4930,9 @@
             }
         },
         "react-native-webview": {
-            "version": "11.6.2",
-            "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.6.2.tgz",
-            "integrity": "sha512-7e5ltLBgqt1mX0gdTTS2nFPIjfS6y300wqJ4rLWqU71lDO+8ZeayfsF5qo83qxo2Go74CtLnSeWae4pdGwUqYw==",
+            "version": "11.26.1",
+            "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.26.1.tgz",
+            "integrity": "sha512-hC7BkxOpf+z0UKhxFSFTPAM4shQzYmZHoELa6/8a/MspcjEP7ukYKpuSUTLDywQditT8yI9idfcKvfZDKQExGw==",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "2.9.0",
     "react-native-svg": "9.13.6",
-    "react-native-webview": "11.6.2",
+    "react-native-webview": "11.26.1",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-clipboard/clipboard": "1.9.0",
     "react-native-gesture-handler": "2.3.1",


### PR DESCRIPTION
After [upgrading the libraries to use Android API 33](https://github.com/wordpress-mobile/react-native-libraries-publisher/pull/17), the library `react-native-webview` couldn't be published due to a build error ([reference](https://buildkite.com/automattic/react-native-libraries-publisher/builds/35#01883332-ad60-4669-afde-ad15d31fba1c/159-571)):

```
/workdir/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java:275: error: cannot find symbol
        view.getSettings().setAppCachePath(ctx.getCacheDir().getAbsolutePath());
                          ^
  symbol:   method setAppCachePath(String)
  location: class WebSettings
/workdir/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java:277: error: cannot find symbol
        view.getSettings().setAppCacheEnabled(true);
                          ^
  symbol:   method setAppCacheEnabled(boolean)
  location: class WebSettings
/workdir/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java:281: error: cannot find symbol
      view.getSettings().setAppCacheEnabled(false);
                        ^
  symbol:   method setAppCacheEnabled(boolean)
  location: class WebSettings
/workdir/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java:475: error: cannot find symbol
    view.getSettings().setAppCacheEnabled(false);
                      ^
  symbol:   method setAppCacheEnabled(boolean)
  location: class WebSettings
```

On Android 13, `setAppCacheEnabled` function is deprecated. This was already solved in the library (https://github.com/react-native-webview/react-native-webview/issues/2547), so we can simply bump the library to the latest `11` version to address the issue. Seems there are no breaking changes between `11.6.2` to [`11.26.1`](https://github.com/react-native-webview/react-native-webview/releases/tag/v11.26.1).

**NOTE:** As mentioned [here](https://github.com/wordpress-mobile/react-native-libraries-publisher/pull/18#issuecomment-1554347502), we keep using version `11` as version `12` is not working properly.