### PR TITLE
Add parameter to allow publish libraries locally

### DIFF
--- a/.buildkite/publish-libraries.sh
+++ b/.buildkite/publish-libraries.sh
@@ -18,9 +18,17 @@ react-native-fast-image
 for project in "${PROJECTS[@]}"
 do
     EXIT_CODE=0
-    ./gradlew :$project:assertVersionIsNotAlreadyPublished || EXIT_CODE=$?
-    # If the project is not published already, publish it
-    if [ $EXIT_CODE -eq 0 ]; then
-        ./gradlew :$project:publishS3PublicationToS3Repository
+    if [ "${USE_MAVEN_LOCAL:-False}" == "True" ]; then
+        echo "========================="
+        echo "Publishing to Maven local"
+        echo "Project: $project"
+        echo "========================="
+        ./gradlew -DDISABLE_PUBLISH_TO_S3=true $project:publishToMavenLocal
+    else
+        ./gradlew :$project:assertVersionIsNotAlreadyPublished || EXIT_CODE=$?
+        # If the project is not published already, publish it
+        if [ $EXIT_CODE -eq 0 ]; then
+            ./gradlew :$project:publishS3PublicationToS3Repository
+        fi
     fi
 done

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     id("com.automattic.android.publish-to-s3") apply false
 }
 
+val disablePublishToS3 = System.getProperty("DISABLE_PUBLISH_TO_S3")?.toBoolean() ?: false
 val defaultCompileSdkVersion = 33
 val defaultMinSdkVersion = 24
 val defaultTargetSdkVersion = 33
@@ -43,7 +44,9 @@ val publishGroupId = "org.wordpress-mobile.react-native-libraries.$publisherVers
 
 subprojects {
     apply(plugin = "maven-publish")
-    apply(plugin = "com.automattic.android.publish-to-s3")
+    if ( !disablePublishToS3 ) {
+        apply(plugin = "com.automattic.android.publish-to-s3")
+    }
 
     repositories {
         exclusiveContent {


### PR DESCRIPTION
Before updating a library, we should first test if the library can be built without failures to avoid errors when publishing it. Currently, we can do this by running the command `./gradlew <library>:publishToMavenLocal`. However, this gives an error if the library is already published.

This PR adds a parameter to solve this issue and allows us to test that all libraries build successfully by running `USE_MAVEN_LOCAL=True .buildkite/publish-libraries.sh`. This can be especially useful when upgrading the React Native version.

Additionally, publishing the libraries to Maven Local lets us test new versions in Gutenberg Mobile without publishing.

### How to test
1. Run the command `USE_MAVEN_LOCAL=True .buildkite/publish-libraries.sh`.
2. Observe that all libraries are built and published successfully in the local folder `~/.m2/repository/org/wordpress-mobile/react-native-libraries`.