### PR TITLE
build: Ignore local tool version configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .gradle
 .idea
 build
+.tool-versions


### PR DESCRIPTION
Similar to `.nvmrc` or `.ruby-version`, `.tool-version` configures local
machine tool versions using asdf-vm. Ignoring this file enables using
asdf-vm without accidental additions of this configuration file.

https://asdf-vm.com/manage/configuration.html#tool-versions
