### PR TITLE
build: Upgrade various packages for React Native 0.71

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2881,9 +2881,9 @@
             }
         },
         "@react-native-clipboard/clipboard": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.9.0.tgz",
-            "integrity": "sha512-O/ohFq1CAQLfoNc376Z3W6gvVcCJlje5AVk0JhsI8Q40hn+NXAWCnOM1bEePfC0uDMtp0/RCK6FotUvkQ6c4Zw==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz",
+            "integrity": "sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==",
             "dev": true
         },
         "@react-native-community/cli-clean": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3560,7 +3560,7 @@
         "boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "dev": true
         },
         "brace-expansion": {
@@ -3920,15 +3920,16 @@
             }
         },
         "css-select": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-            "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
             "dev": true,
             "requires": {
                 "boolbase": "^1.0.0",
-                "css-what": "^3.2.1",
-                "domutils": "^1.7.0",
-                "nth-check": "^1.0.2"
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
             }
         },
         "css-tree": {
@@ -3950,9 +3951,9 @@
             }
         },
         "css-what": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-            "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
             "dev": true
         },
         "dayjs": {
@@ -4076,37 +4077,40 @@
             "dev": true
         },
         "dom-serializer": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-            "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dev": true,
             "requires": {
-                "domelementtype": "^2.0.1",
-                "entities": "^2.0.0"
-            },
-            "dependencies": {
-                "domelementtype": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-                    "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-                    "dev": true
-                }
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             }
         },
         "domelementtype": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "dev": true
         },
-        "domutils": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+        "domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
             "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
+                "domelementtype": "^2.3.0"
+            }
+        },
+        "domutils": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
             }
         },
         "ee-first": {
@@ -4143,9 +4147,9 @@
             }
         },
         "entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true
         },
         "envinfo": {
@@ -6206,12 +6210,12 @@
             }
         },
         "nth-check": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0"
+                "boolbase": "^1.0.0"
             }
         },
         "nullthrows": {
@@ -6876,13 +6880,13 @@
             }
         },
         "react-native-svg": {
-            "version": "9.13.6",
-            "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-9.13.6.tgz",
-            "integrity": "sha512-vjjuJhEhQCwWjqsgWyGy6/C/LIBM2REDxB40FU1PMhi8T3zQUwUHnA6M15pJKlQG8vaZyA+QnLyIVhjtujRgig==",
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-13.9.0.tgz",
+            "integrity": "sha512-Ey18POH0dA0ob/QiwCBVrxIiwflhYuw0P0hBlOHeY4J5cdbs8ngdKHeWC/Kt9+ryP6fNoEQ1PUgPYw2Bs/rp5Q==",
             "dev": true,
             "requires": {
-                "css-select": "^2.0.2",
-                "css-tree": "^1.0.0-alpha.37"
+                "css-select": "^5.1.0",
+                "css-tree": "^1.1.3"
             }
         },
         "react-native-webview": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6854,9 +6854,9 @@
             }
         },
         "react-native-safe-area-context": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz",
-            "integrity": "sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.6.3.tgz",
+            "integrity": "sha512-3CeZM9HFXkuqiU9HqhOQp1yxhXw6q99axPWrT+VJkITd67gnPSU03+U27Xk2/cr9XrLUnakM07kj7H0hdPnFiQ==",
             "dev": true
         },
         "react-native-screens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3099,9 +3099,9 @@
             }
         },
         "@react-native-masked-view/masked-view": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.2.6.tgz",
-            "integrity": "sha512-303CxmetUmgiX9NSUxatZkNh9qTYYdiM8xkGf9I3Uj20U3eGY3M78ljeNQ4UVCJA+FNGS5nC1dtS9GjIqvB4dg==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.2.9.tgz",
+            "integrity": "sha512-Hs4vKBKj+15VxHZHFtMaFWSBxXoOE5Ea8saoigWhahp8Mepssm0ezU+2pTl7DK9z8Y9s5uOl/aPb4QmBZ3R3Zw==",
             "dev": true
         },
         "@react-native/assets": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6718,6 +6718,12 @@
                 }
             }
         },
+        "react-freeze": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
+            "integrity": "sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g==",
+            "dev": true
+        },
         "react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -6860,10 +6866,14 @@
             "dev": true
         },
         "react-native-screens": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.9.0.tgz",
-            "integrity": "sha512-5MaiUD6HA3nzY3JbVI8l3V7pKedtxQF3d8qktTVI0WmWXTI4QzqOU8r8fPVvfKo3MhOXwhWBjr+kQ7DZaIQQeg==",
-            "dev": true
+            "version": "3.22.0",
+            "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.22.0.tgz",
+            "integrity": "sha512-csLypBSXIt/egh37YJmokETptZJCtZdoZBsZNLR9n31GesDyVogprT+MM22dEPDuxPxt/mFWq+lSpVwk7khuTw==",
+            "dev": true,
+            "requires": {
+                "react-freeze": "^1.0.0",
+                "warn-once": "^0.1.0"
+            }
         },
         "react-native-svg": {
             "version": "9.13.6",
@@ -7937,6 +7947,12 @@
             "requires": {
                 "makeerror": "1.0.12"
             }
+        },
+        "warn-once": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+            "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
+            "dev": true
         },
         "wcwidth": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "react-native-get-random-values": "1.4.0",
     "react-native-safe-area-context": "4.6.3",
-    "react-native-screens": "2.9.0",
+    "react-native-screens": "3.22.0",
     "react-native-svg": "9.13.6",
     "react-native-webview": "11.26.1",
     "@react-native-masked-view/masked-view": "0.2.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "react-native-get-random-values": "1.4.0",
-    "react-native-safe-area-context": "3.2.0",
+    "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "2.9.0",
     "react-native-svg": "9.13.6",
     "react-native-webview": "11.26.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "react-native-get-random-values": "1.4.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "3.22.0",
-    "react-native-svg": "9.13.6",
+    "react-native-svg": "13.9.0",
     "react-native-webview": "11.26.1",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-clipboard/clipboard": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "react-native-screens": "3.22.0",
     "react-native-svg": "13.9.0",
     "react-native-webview": "11.26.1",
-    "@react-native-masked-view/masked-view": "0.2.6",
+    "@react-native-masked-view/masked-view": "0.2.9",
     "@react-native-clipboard/clipboard": "1.9.0",
     "react-native-fast-image": "8.5.11",
     "react-native-reanimated": "2.17.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "react-native-svg": "13.9.0",
     "react-native-webview": "11.26.1",
     "@react-native-masked-view/masked-view": "0.2.9",
-    "@react-native-clipboard/clipboard": "1.9.0",
+    "@react-native-clipboard/clipboard": "1.11.2",
     "react-native-fast-image": "8.5.11",
     "react-native-reanimated": "2.17.0",
     "react-native-gesture-handler": "2.10.2",


### PR DESCRIPTION
Upgrade the follow packages for React Native 0.71 compatibility. These mirror upgrade found in https://github.com/WordPress/gutenberg/pull/51303. 

- build: Update react-native-safe-area-context to 4.6.3
- build: Upgrade react-native-screens to 3.22.0
- build: Upgrade react-native-svg to 13.9.0
- build: Upgrade @react-native-masked-view/masked-view to 0.2.9
- build: Upgrade @react-native-clipboard/clipboard to 1.11.2

## How to test

1. Run the command `npm install`.
1. Run the command `./gradlew publishToMavenLocal -exclude-task prepareToPublishToS3`.
1. Observe that all libraries are built and published successfully in the local folder `~/.m2/repository/org/wordpress-mobile/react-native-libraries`.
