### PR TITLE
Upgrade default target sdk version to Android API 34 (Android 14)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ import org.json.JSONObject
 // Although this allows different clients to use different artifacts, since we only have one client
 // this is now the most important use case for this implementation. Instead, this implementation
 // aims to make it easier to test publisher changes without having to override the artifacts.
-val publisherVersion = "v3"
+val publisherVersion = "v4"
 
 plugins {
     id("com.android.library") apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,9 @@ plugins {
     id("com.automattic.android.publish-to-s3") apply false
 }
 
-val defaultCompileSdkVersion = 33
+val defaultCompileSdkVersion = 34
 val defaultMinSdkVersion = 24
-val defaultTargetSdkVersion = 33
+val defaultTargetSdkVersion = 34
 val excludeAppGlideModule = true
 
 // Set project extra properties


### PR DESCRIPTION
This PR bumps the default SDK version to API 34. To re-generate the binaries, the publisher version has been bumped too.

## How to test
1. Run the command: `CLIENT_SIDE_BUILD="True" JS_RUNTIME="hermes" ./gradlew publishToMavenLocal -exclude-task prepareToPublishToS3`.
2. Observe that all libraries are built and published successfully in the local folder `~/.m2/repository/org/wordpress-mobile/react-native-libraries`.
3. Test the editor building the Gutenberg demo app using changes from https://github.com/WordPress/gutenberg/pull/61727.