### PR TITLE
Update publishing group id from org.wordpress-mobile.react-native-libraries to org.wordpress.react-native-libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Once the package is added as a dependency, or if it was already included, add a 
 
 **Example**:
 ```
-implementation "org.wordpress:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
+implementation "org.wordpress.react-native-libraries:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
 ```
 
 **NOTE:** The version of the artifact will be extracted from the `package.json` file of the package.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Once the package is added as a dependency, or if it was already included, add a 
 
 **Example**:
 ```
-implementation "org.wordpress-mobile:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
+implementation "org.wordpress:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
 ```
 
 **NOTE:** The version of the artifact will be extracted from the `package.json` file of the package.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ import org.json.JSONObject
 // Although this allows different clients to use different artifacts, since we only have one client
 // this is now the most important use case for this implementation. Instead, this implementation
 // aims to make it easier to test publisher changes without having to override the artifacts.
-val publisherVersion = "v3"
+val publisherVersion = "v4"
 
 plugins {
     id("com.android.library") apply false
@@ -39,7 +39,7 @@ val packageDevDependencies = packageJson.optJSONObject("devDependencies")
 
 val reactNativeVersion = packageDevDependencies.optString("react-native")
 
-val publishGroupId = "org.wordpress-mobile.react-native-libraries.$publisherVersion"
+val publishGroupId = "org.wordpress.react-native-libraries.$publisherVersion"
 
 subprojects {
     apply(plugin = "maven-publish")


### PR DESCRIPTION
This PR updates the publishing group id from `org.wordpress-mobile.react-native-libraries` to `org.wordpress.react-native-libraries`. I've also taken the opportunity to fix a small mistake in `README` where the example was using `org.wordpress-mobile` as group id whereas it should have been `org.wordpress-mobile.react-native-libraries` - and now it should be `org.wordpress.react-native-libraries`.

I updated the `publisherVersion` because even though this is not a breaking change, I want to use it to make the `gutenberg` repository change a breaking one and prevent the possibility of accidentally fetching from the `org.wordpress-mobile` domain.